### PR TITLE
Rename project to 'mazette'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Assets
+# Mazette
 
-The `assets` tool is a Python script designed to manage assets from GitHub
+The `mazette` tool is a Python script designed to manage assets from GitHub
 releases. It expects a configuration file (in TOML format) that contains a list
 of assets and some parameters. Using this config file, it can query GitHub for
 release information, compute checksums for assets, update a lock file (JSON
@@ -38,16 +38,16 @@ source.
 
 First you need to clone this repository. Then, we suggest
 [installing](https://docs.astral.sh/uv/getting-started/installation/) `uv`. Once
-you've installed `uv`, you can run the script with `./assets.py --help`. The
+you've installed `uv`, you can run the script with `./mazette.py --help`. The
 installation of dependencies is handled internally by `uv`.
 
 ## Configuration
 
 Before you begin working with the script, you must create a configuration file
 in one of the following locations of your project:
-* `assets.toml`: This is a config file written specifically for this tool.
+* `mazette.toml`: This is a config file written specifically for this tool.
 * `pyproject.toml`: This is a config file written for a Python project. The
-  assets tool expects a `[tool.assets]` section in this file.
+  mazette tool expects a `[tool.mazette]` section in this file.
 
 ### Examples
 
@@ -66,7 +66,7 @@ extract = false
 ```
 
 If you are using `pyproject.toml` as a config file, then you need to prepend
-`tool.assets` to the section name, e.g., `[tool.assets.asset.example]`.
+`tool.mazette` to the section name, e.g., `[tool.mazette.asset.example]`.
 
 ### `repo`
 
@@ -154,7 +154,7 @@ destination root. By default the file hierarchy in the archive is preserved.
 
 ## Commands
 
-The assets script supports three commands:
+The mazette script supports three commands:
 - `lock`
 - `install`
 - `list`
@@ -164,7 +164,7 @@ The following sections assume you invoke the script with `poetry run`.
 ### `lock`
 
 The `lock` command updates the lock file based on the configuration defined in
-`pyproject.toml` / `assets.toml`. For each asset, it reads its details,
+`pyproject.toml` / `mazette.toml`. For each asset, it reads its details,
 queries GitHub to find the appropriate release and asset URL, computes a
 checksum if the asset is available locally, uses caching for fetching and
 hashing, renders filenames that contain the `{version}` template string, and
@@ -173,10 +173,10 @@ supports assets that are platform-agnostic using `platform.all`.
 Example:
 
 ```
-./assets.py lock
+./mazette.py lock
 Processing 'asset1'
 Processing 'asset2'
-Lock file 'assets.lock' updated.
+Lock file 'mazette.lock' updated.
 ```
 
 ### `install`
@@ -192,7 +192,7 @@ Examples:
 Install all assets for the current platform:
 
 ```
-./assets.py install
+./mazette.py install
 Installing 'asset1'
 Installing 'asset2'
 Installed 2 assets.
@@ -201,7 +201,7 @@ Installed 2 assets.
 Install all assets for the provided platform:
 
 ```
-./assets.py install -p darwin/amd64
+./mazette.py install -p darwin/amd64
 Installing 'asset3'
 Installed 1 assets.
 ```
@@ -209,7 +209,7 @@ Installed 1 assets.
 Install only specific assets:
 
 ```
-./assets.py install asset1
+./mazette.py install asset1
 Installing 'asset1'
 Installed 1 assets.
 ```
@@ -223,7 +223,7 @@ its version, and its download URL.
 Example:
 
 ```
-./assets.py list
+./mazette.py list
 asset1 0.0.1 https://github.com/owner/repo/releases/download/v0.0.1/asset1
 asset2 1.2.3 https://github.com/owner/other/releases/download/v0.0.1/asset2
 ```
@@ -249,7 +249,7 @@ Each command supports the following optional arguments:
 
 ## License
 
-The assets tool is licensed under either of:
+The mazette tool is licensed under either of:
 
 * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
 * MIT license ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/licenses/MIT)

--- a/mazette.py
+++ b/mazette.py
@@ -40,13 +40,13 @@ from colorama import Fore, Style
 from platformdirs import user_cache_dir
 
 # CONSTANTS
-CONFIG_FILE = Path("assets.toml")
+CONFIG_FILE = Path("mazette.toml")
 PYPROJECT_FILE = Path("pyproject.toml")
-LOCK_FILE = Path("assets.lock")
+LOCK_FILE = Path("mazette.lock")
 GITHUB_API_URL = "https://api.github.com"
 
 # Determine the cache directory using platformdirs
-CACHE_ROOT = Path(user_cache_dir("assets"))
+CACHE_ROOT = Path(user_cache_dir("mazette"))
 
 
 logger = logging.getLogger(__name__)
@@ -111,11 +111,11 @@ def report_error(verbose=False, fail=False):
 
 def read_config():
     """
-    Read the config for the assets tool, either from its own configuration file
-    (assets.toml) or a [tool.assets] section in pyproject.toml.
+    Read the config for the mazette tool, either from its own configuration file
+    (mazette.toml) or a [tool.mazette] section in pyproject.toml.
     """
     if CONFIG_FILE.exists():
-        # First, attempt to read the configuration from assets.toml.
+        # First, attempt to read the configuration from mazette.toml.
         try:
             return toml.loads(CONFIG_FILE.read_text())
         except Exception as e:
@@ -129,18 +129,18 @@ def read_config():
             msg = f"Could not load configuration file '{PYPROJECT_FILE}': {e}"
             raise AssetException(msg) from e
 
-        # If the pyproject.toml file does not have a [tool.assets] section, return an
+        # If the pyproject.toml file does not have a [tool.mazette] section, return an
         # error.
         try:
-            return config["tool"]["assets"]
+            return config["tool"]["mazette"]
         except KeyError:
             raise AssetException(
-                f"Missing a '[tool.assets]' section in {PYPROJECT_FILE} or"
+                f"Missing a '[tool.mazette]' section in {PYPROJECT_FILE} or"
                 f" a separate {CONFIG_FILE}"
             )
 
     raise AssetException(
-        f"Missing a {PYPROJECT_FILE} with a '[tool.assets]' or a separate"
+        f"Missing a {PYPROJECT_FILE} with a '[tool.mazette]' or a separate"
         f" {CONFIG_FILE}"
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
-name = "assets"
-version = "0.1.0"
+name = "mazette"
+version = "0.2.0"
 description = "GitHub asset management with lock files and extensive configuration"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -13,4 +13,4 @@ dependencies = [
 ]
 
 [project.scripts]
-assets = "assets:main"
+mazette = "mazette:main"

--- a/uv.lock
+++ b/uv.lock
@@ -3,27 +3,6 @@ revision = 2
 requires-python = ">=3.9"
 
 [[package]]
-name = "assets"
-version = "0.1.0"
-source = { virtual = "." }
-dependencies = [
-    { name = "colorama" },
-    { name = "platformdirs" },
-    { name = "requests" },
-    { name = "semver" },
-    { name = "toml" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "colorama", specifier = ">=0.4.6" },
-    { name = "platformdirs", specifier = ">=4.3.8" },
-    { name = "requests", specifier = ">=2.32.3" },
-    { name = "semver", specifier = ">=3.0.4" },
-    { name = "toml", specifier = ">=0.10.2" },
-]
-
-[[package]]
 name = "certifi"
 version = "2025.4.26"
 source = { registry = "https://pypi.org/simple" }
@@ -122,6 +101,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+]
+
+[[package]]
+name = "mazette"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "colorama" },
+    { name = "platformdirs" },
+    { name = "requests" },
+    { name = "semver" },
+    { name = "toml" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "colorama", specifier = ">=0.4.6" },
+    { name = "platformdirs", specifier = ">=4.3.8" },
+    { name = "requests", specifier = ">=2.32.3" },
+    { name = "semver", specifier = ">=3.0.4" },
+    { name = "toml", specifier = ">=0.10.2" },
 ]
 
 [[package]]


### PR DESCRIPTION
Rename 'assets' projects to 'mazette', to give it a more... unique name. The name itself is not too interesting, it just came to be when we were thinking of names, and ran out of them while entering a brewery in Brussels called, well, Mazette!

And it's not taken in PyPI, so that's cool.

Closes #1