### PR TITLE
Make whole directories executable, if the asset is marked as executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,16 @@ assets".
 
 ## Installation
 
-The script is not currently pushed to PyPI, so you need to work with it from
-source.
+```
+python -m pip install mazette
+```
 
-First you need to clone this repository. Then, we suggest
-[installing](https://docs.astral.sh/uv/getting-started/installation/) `uv`. Once
-you've installed `uv`, you can run the script with `./mazette.py --help`. The
-installation of dependencies is handled internally by `uv`.
+Alternatively, you can run it directly with
+[`uvx`](https://docs.astral.sh/uv/guides/tools/#running-tools):
+
+```
+uvx mazette --help
+```
 
 ## Configuration
 

--- a/mazette.py
+++ b/mazette.py
@@ -635,9 +635,10 @@ def install_asset(name, platform, asset_dict):
         logger.debug(f"Copying asset '{name}' to '{asset.destination}'")
         asset.destination.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(cached_file, asset.destination)
-        if asset.executable:
-            logger.debug(f"Marking '{asset.destination}' as executable")
-            chmod_exec(asset.destination)
+    # If the destination should be executable.
+    if asset.executable:
+        logger.debug(f"Marking '{asset.destination}' as executable")
+        chmod_exec(asset.destination)
 
 
 # COMMAND FUNCTIONS

--- a/mazette.py
+++ b/mazette.py
@@ -628,7 +628,6 @@ def install_asset(name, platform, asset_dict):
     if asset.extract:
         logger.debug(f"Extracting asset '{name}' to '{asset.destination}'")
         asset.destination.mkdir(parents=True, exist_ok=True)
-        filename = asset.download_url.split("/")[-1]
         extract_asset(
             cached_file, asset.destination, **dataclasses.asdict(asset.extract)
         )

--- a/mazette.py
+++ b/mazette.py
@@ -1,14 +1,5 @@
-#!/usr/bin/env -S uv run --script
-# /// script
-# requires-python = ">=3.9"
-# dependencies = [
-#     "colorama",
-#     "platformdirs",
-#     "requests",
-#     "semver",
-#     "toml",
-# ]
-# ///
+#!/usr/bin/env python3
+
 """
 GitHub assets management
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mazette"
-version = "0.2.0"
+version = "0.2.1"
 description = "GitHub asset management with lock files and extensive configuration"
 authors = [{ name = "Freedom of the Press Foundation", email = "info@freedom.press" }]
 readme = "README.md"


### PR DESCRIPTION
Fix an issue with assets that were archives and marked as executable. In this case, the files in these archives should be marked as executable after they are extracted. In practice, the executable option applied only to single files.

Fixes #6